### PR TITLE
conf/machine/nxp-imx6.conf: add u-boot-imx to EXTRA_IMAGEDEPENDS

### DIFF
--- a/conf/machine/nxp-imx6.conf
+++ b/conf/machine/nxp-imx6.conf
@@ -28,4 +28,4 @@ IMAGE_INSTALL_append = " kernel-devicetree kernel-image-zimage"
 
 IMAGE_BOOT_FILES ?= "zImage imx6q-sabresd.dtb imx6sx-sdb.dtb boot.scr"
 
-EXTRA_IMAGEDEPENDS_append_nxp-imx6 += "u-boot-imx-uenv"
+EXTRA_IMAGEDEPENDS_append_nxp-imx6 += "u-boot-imx-uenv u-boot-imx"


### PR DESCRIPTION
While the following commit applied in oe-core
...
commit 918d043ec2ae080d85e47e2c0eb7b7cc571b34a1
Author: Ming Liu <liu.ming50@gmail.com>
Date:   Tue Sep 26 14:31:16 2017 +0200

    image.bbclass: let do_image depend on do_populate_lic of EXTRA_IMAGEDEPENDS
...

Add u-boot-imx to EXTRA_IMAGEDEPENDS could fix a dependency missing
between initramfs-ostree-image do_image and u-boot-imx do_populate_lic
...
|Exception: FileNotFoundError: [Errno 2] No such file or directory:
tmp/deploy/licenses/u-boot-imx/recipeinfo'
|ERROR: initramfs-ostree-image-1.0-r0 do_image_complete:
Function failed: write_deploy_manifest
...

Issue: US113249

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>