### PR TITLE
nxp_imx6:rename partition lable on eMMC

### DIFF
--- a/recipes-bsp/u-boot/u-boot-imx-uenv.bb
+++ b/recipes-bsp/u-boot/u-boot-imx-uenv.bb
@@ -16,11 +16,11 @@ do_compile(){
 setenv machine_name nxp-imx6
 if test \${skip_script_fdt} != yes; then setenv fdt_file ${SECO_DEFAULT_DTB}; fi
 setenv mmcpart 5
-setenv rootpart ostree_root=LABEL=\${labelpre}otaroot
-setenv bootpart ostree_boot=LABEL=\${labelpre}otaboot
+setenv rootpart ostree_root=LABEL=otaroot\${labelpre}
+setenv bootpart ostree_boot=LABEL=otaboot\${labelpre}
 setenv mmcpart_r 7
-setenv rootpart_r ostree_root=LABEL=\${labelpre}otaroot_b
-setenv bootpart_r ostree_boot=LABEL=\${labelpre}otaboot_b
+setenv rootpart_r ostree_root=LABEL=otaroot_b\${labelpre}
+setenv bootpart_r ostree_boot=LABEL=otaboot_b\${labelpre}
 setenv abflag A
 if fatload mmc \${mmcdev}:1 \${fdt_addr} boot_ab_flag;then setexpr.l abflagv *\${fdt_addr}; if test \${abflagv} = 42333231;then setenv abflag B;fi;fi
 setexpr fdt_addr1 \${fdt_addr} + 2
@@ -29,7 +29,7 @@ mw.l \${fdt_addr2} 52570030
 setenv switchab if test \${abflag} = B\\;then setenv abflag A\\;mw.l \${fdt_addr} 41333231\\;else setenv abflag B\\;mw.l \${fdt_addr} 42333231\\;fi\\;fatwrite mmc \${mmcdev}:1 \${fdt_addr} boot_ab_flag 4
 if fatload mmc \${mmcdev}:1 \${fdt_addr} boot_cnt;then setexpr.w cntv0 *\${fdt_addr1}; if test \${cntv0} = 5257;then setexpr.b cntv *\${fdt_addr};if test \${cntv} > 32;then run switchab;else setexpr.b cntv \${cntv} + 1;mw.b \${fdt_addr2} \${cntv};fi;fi;fi
 fatwrite mmc \${mmcdev}:1 \${fdt_addr2} boot_cnt 4
-if test \${abflag} = B; then setenv mmcpart 7;setenv rootpart ostree_root=LABEL=\${labelpre}otaroot_b;setenv bootpart ostree_boot=LABEL=\${labelpre}otaboot_b;setenv mmcpart_r 5; setenv rootpart_r ostree_root=LABEL=\${labelpre}otaroot; setenv bootpart_r ostree_boot=LABEL=\${labelpre}otaboot;echo "B as active, A as rollback";else echo "A as active, B as rollback";fi
+if test \${abflag} = B; then setenv mmcpart 7;setenv rootpart ostree_root=LABEL=otaroot_b\${labelpre};setenv bootpart ostree_boot=LABEL=otaboot_b\${labelpre};setenv mmcpart_r 5; setenv rootpart_r ostree_root=LABEL=otaroot\${labelpre}; setenv bootpart_r ostree_boot=LABEL=otaboot\${labelpre};echo "B as active, A as rollback";else echo "A as active, B as rollback";fi
 if test -n \${rollback_f} && test \${rollback_f} = yes;then setenv mmcpart \${mmcpart_r}; setenv rootpart \${rootpart_r}; setenv bootpart \${bootpart_r}; echo "Perform rollback";fi
 setenv loadenvscript ext4load mmc \${mmcdev}:\${mmcpart} \${loadaddr} /loader/uEnv.txt
 run loadenvscript  && env import -t \${loadaddr} 0x40000
@@ -40,7 +40,7 @@ if test \${skip_script_wd} != yes; then setenv wdttimeout 120000; fi
 run loadramdisk
 run loaddtb
 run loadkernel
-setenv bootargs \${bootargs} \${bootpart} \${rootpart} console=\${console},\${baudrate} \${smp} flux=\${labelpre}fluxdata
+setenv bootargs \${bootargs} \${bootpart} \${rootpart} console=\${console},\${baudrate} \${smp} flux=fluxdata\${labelpre}
 bootz \${loadaddr} \${initrd_addr} \${fdt_addr}
 EOF
 

--- a/recipes-bsp/u-boot/u-boot-imx/0004-seco-auto-select-booting-device.patch
+++ b/recipes-bsp/u-boot/u-boot-imx/0004-seco-auto-select-booting-device.patch
@@ -25,7 +25,7 @@ index 572be48..aca13e1 100644
 +		break;
 +	case 2:
 +		puts("Boot from eMMC\n");
-+		setenv("labelpre", "emmc_");
++		setenv("labelpre", "_hd");
 +		dev_no = 1;
 +		break;
 +	default:

--- a/recipes-extended/ostree-deploy/files/ostree-deploy.sh
+++ b/recipes-extended/ostree-deploy/files/ostree-deploy.sh
@@ -236,13 +236,15 @@ EOF
 		cd - >/dev/null 2>&1
 	fi
 	if [ $CREATE_EMMC -eq 1 ]; then
+		label_append="_hd"
 		echo "reset label for eMMC"
-		e2label ${device}p5 emmc_otaboot
-		e2label ${device}p6 emmc_otaroot
-		e2label ${device}p7 emmc_otaboot_b
-		e2label ${device}p8 emmc_otaroot_b
-		e2label ${device}p3 emmc_fluxdata
+		e2label ${device}p5 otaboot${label_append}
+		e2label ${device}p6 otaroot${label_append}
+		e2label ${device}p7 otaboot_b${label_append}
+		e2label ${device}p8 otaroot_b${label_append}
+		e2label ${device}p3 fluxdata${label_append}
 	fi
+	sync
 }
 
 if ! [ -e "/z" ]; then

--- a/recipes-extended/upgrade-mgr/files/pulsar_upgrade.sh
+++ b/recipes-extended/upgrade-mgr/files/pulsar_upgrade.sh
@@ -29,9 +29,9 @@ if [ x${partroot} = 'x8' ]; then
 	label_append=''
 fi
 label_pre=""
-teststr=`grep "emmc_" /proc/cmdline`
+teststr=`grep "_hd" /proc/cmdline`
 if [ -n "${teststr}" ]; then
-	label_pre="emmc_"
+	label_pre="_hd"
 fi
 
 #Mount backup device
@@ -53,9 +53,9 @@ if [ $testval -ne 0 ]; then
 	umount ${upboot}
 	umount ${uproot}
 	dd if=${runroot} of=${uproot} bs=1M status=progress
-	e2label ${uproot} ${label_pre}otaroot${label_append}
+	e2label ${uproot} otaroot${label_append}${label_pre}
 	sleep 0.5
-	e2label ${uproot} ${label_pre}otaroot${label_append}
+	e2label ${uproot} otaroot${label_append}${label_pre}
 	sync
 	mount ${uproot} /tmp/sysroot_b
 	testval=$?
@@ -69,9 +69,9 @@ if [ $testval -ne 0 ]; then
 	fi
 
 	dd if=${runboot} of=${upboot} bs=1M status=progress
-	e2label ${upboot} ${label_pre}otaboot${label_append}
+	e2label ${upboot} otaboot${label_append}${label_pre}
 	sleep 0.5
-	e2label ${upboot} ${label_pre}otaboot${label_append}
+	e2label ${upboot} otaboot${label_append}${label_pre}
 	sync
 	mount ${upboot} /tmp/sysroot_b/boot
 	testval=$?

--- a/recipes-extended/upgrade-mgr/files/sd_emmc.sh
+++ b/recipes-extended/upgrade-mgr/files/sd_emmc.sh
@@ -3,6 +3,8 @@
 sd=mmcblk0
 emmc=mmcblk2
 
+label_append="_hd"
+
 #dd basic part
 sd3=${sd}p3
 test=`fdisk -l /dev/${sd} |awk '/'$sd3'/{print $2}'`
@@ -35,17 +37,17 @@ umount /tmp/mnt0
 umount /tmp/mnt1
 sync
 rm -rf /tmp/mnt0 /tmp/mnt1
-e2label /dev/${emmc}p3 emmc_fluxdata
+e2label /dev/${emmc}p3 fluxdata${label_append}
 sleep 0.5
-e2label /dev/${emmc}p5 emmc_otaboot
+e2label /dev/${emmc}p5 otaboot${label_append}
 sleep 0.5
-e2label /dev/${emmc}p6 emmc_otaroot
+e2label /dev/${emmc}p6 otaroot${label_append}
 sleep 0.5
-e2label /dev/${emmc}p6 emmc_otaroot
+e2label /dev/${emmc}p6 otaroot${label_append}
 sleep 0.5
-e2label /dev/${emmc}p7 emmc_otaboot_b
+e2label /dev/${emmc}p7 otaboot_b${label_append}
 sleep 0.5
-e2label /dev/${emmc}p8 emmc_otaroot_b
+e2label /dev/${emmc}p8 otaroot_b${label_append}
 sleep 0.5
-e2label /dev/${emmc}p8 emmc_otaroot_b
+e2label /dev/${emmc}p8 otaroot_b${label_append}
 sync

--- a/recipes-extended/upgrade-mgr/upgrade-mgr_1.0.bb
+++ b/recipes-extended/upgrade-mgr/upgrade-mgr_1.0.bb
@@ -4,14 +4,14 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
 SRC_URI = "\
-	file://upgrade_inactive_partition.sh \
+	file://pulsar_upgrade.sh \
 	file://sd_emmc.sh \
 "
 FILESEXTRAPATHS_prepend := "${THISDIR}:${THISDIR}/files:"
 
 do_install() {
 	install -d ${D}${sbindir}
-	install -m 0755 ${WORKDIR}/upgrade_inactive_partition.sh ${D}${sbindir}
+	install -m 0755 ${WORKDIR}/pulsar_upgrade.sh ${D}${sbindir}
 	install -m 0755 ${WORKDIR}/sd_emmc.sh ${D}${sbindir}
 }
 


### PR DESCRIPTION
Use '_hd' suffix to replace 'emmc_' prefix in partition label on eMMC device.

Rename upgrade script to pular_upgrade.sh.

Signed-off-by: Jiang Lu <lu.jiang@windriver.com>